### PR TITLE
fix: update product and FAQ titles to reflect branding change from PG…

### DIFF
--- a/src/data/faqs.ts
+++ b/src/data/faqs.ts
@@ -8,7 +8,7 @@ export const FAQS = [
   },
   {
     id: 2,
-    title: "What makes PG-10 effective for equipment maintenance?",
+    title: "What makes Power-10 effective for equipment maintenance?",
     content: `The engine is the heart of an automobile. It is a device that is made of metal that converts the chemical energy of fuel into mechanical energy which is used to drive the vehicle. It is basically a device that produces power. The rotating parts of an engine produce energy from the consumption of fuel and provide energy to the vehicle.`,
   },
   {
@@ -18,12 +18,12 @@ export const FAQS = [
   },
   {
     id: 4,
-    title: "Is TG-10 safe to use on sensitive parts?",
+    title: "Is Power-10 safe to use on sensitive parts?",
     content: `The engine is the heart of an automobile. It is a device that is made of metal that converts the chemical energy of fuel into mechanical energy which is used to drive the vehicle. It is basically a device that produces power. The rotating parts of an engine produce energy from the consumption of fuel and provide energy to the vehicle.`,
   },
   {
     id: 5,
-    title: "What is PG-10, and where and when should I use it?",
+    title: "What is Power-10, and where and when should I use it?",
     content: `The engine is the heart of an automobile. It is a device that is made of metal that converts the chemical energy of fuel into mechanical energy which is used to drive the vehicle. It is basically a device that produces power. The rotating parts of an engine produce energy from the consumption of fuel and provide energy to the vehicle.`,
   },
   {

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -167,11 +167,11 @@ export const PRODUCTS: ProductType[] = [
 
   {
     range: "Premium",
-    title: "PG-10 Critical Maintenance Lubricant",
+    title: "Power-10 Critical Maintenance Lubricant",
     type: "lubrication",
     images: ["/images/products/power-10.jpg"],
-    href: "pg-10",
-    overview: `PG-10 is a high-performance maintenance lubricant spray, engineered with nano-penetrating technology and powered by Tirrent Booster. It penetrates deep to eliminate rust, corrosion, and friction at the micro level—making it up to 20 times stronger than traditional sprays. Ideal for both industrial and household use, PG-10 dramatically extends the life and reliability of metal parts, tools, and electrical components—even in extreme conditions.`,
+    href: "power-10",
+    overview: `Power-10 is a high-performance maintenance lubricant spray, engineered with nano-penetrating technology and powered by Tirrent Booster. It penetrates deep to eliminate rust, corrosion, and friction at the micro level—making it up to 20 times stronger than traditional sprays. Ideal for both industrial and household use, Power-10 dramatically extends the life and reliability of metal parts, tools, and electrical components—even in extreme conditions.`,
     benefits: [
       "Fast & Deep Penetration into metal surfaces",
       "Breaks down rust and corrosion efficiently",


### PR DESCRIPTION
…-10 to Power-10

- Changed all instances of "PG-10" to "Power-10" in the FAQs and product descriptions for consistency with the new branding.
- Ensured that the product overview and titles accurately represent the updated product name.